### PR TITLE
make cli-command examples executable

### DIFF
--- a/cli-usage.md
+++ b/cli-usage.md
@@ -14,7 +14,7 @@ Deploy to TestNet, to an account `$CONTRACT_ID` you have access keys for:
 ```
 export NEAR_ENV=default
 near deploy $CONTRACT_ID --wasmFile=res/ref_exchange.wasm
-near call $CONTRACT_ID new "{\"owner_id\": \"$USER_ID\", \"exchange_fee\": 4, \"referral_fee\": 1}" --accountId $CONTRACT_ID
+near call $CONTRACT_ID new '{\"owner_id\":\"$USER_ID\",\"exchange_fee\":"4",\"referral_fee\":"1"}' --accountId $CONTRACT_ID
 ```
 
 ## Add a simple pool
@@ -22,7 +22,7 @@ near call $CONTRACT_ID new "{\"owner_id\": \"$USER_ID\", \"exchange_fee\": 4, \"
 Add simple pool with 2 tokens and 0.3% total fee (0.04% goes to exchange and 0.01% goes to referral).
 
 ```
-near call $CONTRACT_ID add_simple_pool "{\"tokens\": [\"$TOKEN1\", \"$TOKEN2\"], \"fee\": 25}" --accountId $USER_ID --amount 0.1
+near call $CONTRACT_ID add_simple_pool '{\"tokens\":[\"$TOKEN1\",\"$TOKEN2\"],\"fee\":"25"}' --accountId $USER_ID --amount 0.1
 ```
 
 ## Query pools
@@ -30,7 +30,7 @@ near call $CONTRACT_ID add_simple_pool "{\"tokens\": [\"$TOKEN1\", \"$TOKEN2\"],
 To query first 10 pools:
 
 ```
-near view $CONTRACT_ID get_pools '{"from_index": 0, "limit": 10}'
+near view $CONTRACT_ID get_pools '{\"from_index\":"0",\"limit\":"10"}'
 ```
 
 ## Register account in the exchange
@@ -42,7 +42,7 @@ near call $CONTRACT_ID storage_deposit '' --accountId $USER_ID --amount 0.1
 If there is a token that is not in whitelist, you also need to register it separately:
 
 ```
-near call $CONTRACT_ID register_tokens '{\"token_ids\": [\"$TOKEN1\", \"$TOKEN2\"]}' --accountId $USER_ID
+near call $CONTRACT_ID register_tokens '{\"token_ids\":[\"$TOKEN1\",\"$TOKEN2\"]}' --accountId $USER_ID
 ```
 
 ## Query whitelisted tokens
@@ -56,7 +56,7 @@ near view $CONTRACT_ID get_whitelisted_tokens
 ## Check that account is registered and storage available
 
 ```
-near view $CONTRACT_ID storage_balance_of "{\"account_id\": \"$USER_ID\"}"
+near view $CONTRACT_ID storage_balance_of '{\"account_id\":\"$USER_ID\"}'
 ```
 
 ## Deposit funds
@@ -64,55 +64,55 @@ near view $CONTRACT_ID storage_balance_of "{\"account_id\": \"$USER_ID\"}"
 Before sending funds for token X, make sure that exchange is registered for token X.
 
 ```
-near call $TOKEN1 storage_deposit "{\"account_id\": \"$CONTRACT_ID\"}" --accountId $USER_ID --amount 0.0125
+near call $TOKEN1 storage_deposit '{\"account_id\":\"$CONTRACT_ID\"}' --accountId $USER_ID --amount 0.0125
 ```
 
 Actually deposit funds to the exchange (attaching 1yN for security):
 
 ```
-near call $TOKEN1 ft_transfer_call "{\"receiver_id\": \"$CONTRACT_ID\", \"amount\": \"1000000000000\", \"msg\": \"\"}" --accountId $USER_ID --amount 0.000000000000000000000001
+near call $TOKEN1 ft_transfer_call '{\"receiver_id\":\"$CONTRACT_ID\",\"amount\":\"1000000000000\",\"msg\":\"\"}' --accountId $USER_ID --amount 0.000000000000000000000001
 ```
 
 ## Query deposit balances in the exchange
 
 ```
-near view $CONTRACT_ID get_deposits "{\"account_id\": \"$USER_ID\"}"
+near view $CONTRACT_ID get_deposits '{\"account_id\":\"$USER_ID\"}'
 ```
 
 ## Add liquidity to a pool
 
 ```
-near call $CONTRACT_ID add_liquidity '{"pool_id": 0, "amounts": ["10000", "10000"]}' --accountId $USER_ID --amount 0.000000000000000000000001
+near call $CONTRACT_ID add_liquidity '{\"pool_id\":"0",\"amounts\":["10000","10000"]}' --accountId $USER_ID --amount 0.000000000000000000000001
 ```
 
 ## Get pool's information
 
 ```
-near view $CONTRACT_ID get_pool '{"pool_id": 0}'
+near view $CONTRACT_ID get_pool '{\"pool_id\":"0"}'
 ```
 
 ## Get pool's accumulated volume
 
 ```
-near view $CONTRACT_ID get_pool_volumes '{"pool_id": 0}'
+near view $CONTRACT_ID get_pool_volumes '{\"pool_id\":"0"}'
 ```
 
 ## Get number of liquidity shares in the pool
 
 ```
-near view $CONTRACT_ID get_pool_shares "{\"pool_id\": 0, \"account_id\": \"$USER_ID\"}"
+near view $CONTRACT_ID get_pool_shares '{\"pool_id\":"0",\"account_id\":\"$USER_ID\"}'
 ```
 
 ## Remove liquidity from a pool
 
 ```
-near call $CONTRACT_ID remove_liquidity '{"pool_id": 0, "shares": "1000000000000000000000000", "min_amounts": ["1", "1"]}' --accountId $USER_ID --amount 0.000000000000000000000001
+near call $CONTRACT_ID remove_liquidity '{\"pool_id\":"0",\"shares\":"1000000000000000000000000",\"min_amounts\":["1","1"]}' --accountId $USER_ID --amount 0.000000000000000000000001
 ```
 
 ## Output amount after swap
 
 ```
-near view $CONTRACT_ID get_return "{\"pool_id\": 0, \"token_in\": \"$TOKEN1\", \"amount_in\": \"10000\", \"token_out\": \"$TOKEN2\"}"
+near view $CONTRACT_ID get_return '{\"pool_id\":"0",\"token_in\":\"$TOKEN1\",\"amount_in\":\"10000\",\"token_out\":\"$TOKEN2\"}'
 ```
 
 ## Swap
@@ -120,7 +120,7 @@ near view $CONTRACT_ID get_return "{\"pool_id\": 0, \"token_in\": \"$TOKEN1\", \
 Swap via a single pool:
 
 ```
-near call $CONTRACT_ID swap "{\"actions\": [{\"pool_id\": 0, \"token_in\": \"$TOKEN1\", \"amount_in\": \"10000\", \"token_out\": \"$TOKEN2\", \"min_amount_out\": \"1\"}]}" --accountId $USER_ID --amount 0.000000000000000000000001
+near call $CONTRACT_ID swap '{\"actions\":[{\"pool_id\":"0",\"token_in\":\"$TOKEN1\",\"amount_in\":\"10000\",\"token_out\":\"$TOKEN2\",\"min_amount_out\":\"1\"}]}' --accountId $USER_ID --amount 0.000000000000000000000001
 ```
 
 ## Withdraw funds
@@ -128,7 +128,7 @@ near call $CONTRACT_ID swap "{\"actions\": [{\"pool_id\": 0, \"token_in\": \"$TO
 To withdraw specific token from exchange back to user's account:
 
 ```
-near call $CONTRACT_ID withdraw "{\"token_id\": \"$TOKEN1\", \"amount\": \"900000000000\"}" --accountId $USER_ID --amount 0.000000000000000000000001
+near call $CONTRACT_ID withdraw '{\"token_id\":\"$TOKEN1\",\"amount\":\"900000000000\"}' --accountId $USER_ID --amount 0.000000000000000000000001
 ```
 
 ## Check owner


### PR DESCRIPTION
currently copy-pasting the commands and setting the variable values isn't enough to execute the commands, readers have to still make some modifications the the JSON args:
- JSON strings in args have escaped double quotes, numbers also have double quotes but they remain unescaped
- get rid of all spaces
now this also makes the commands more crammed -> less clear for the reader, but I think It's still less work for him